### PR TITLE
trigger API when conversation is complete

### DIFF
--- a/app/endpoint/controllers.py
+++ b/app/endpoint/controllers.py
@@ -132,13 +132,9 @@ def api():
                     resultJson["speechResponse"] = currentNode["prompt"]
                 else:
                     resultJson["complete"] = True
-
                     context["parameters"] = extractedParameters
             else:
                 resultJson["complete"] = True
-                resultTemplate = Template(
-                    story.speechResponse, undefined=SilentUndefined)
-                resultJson["speechResponse"] = resultTemplate.render(**context)
 
         elif (requestJson.get("complete") is False):
             if "cancel" not in story.intentName:
@@ -168,38 +164,35 @@ def api():
                 resultJson["parameters"] = {}
                 resultJson["intent"] = {}
                 resultJson["complete"] = True
-                template = Template(
-                    story.speechResponse,
-                    undefined=SilentUndefined)
-                resultJson["speechResponse"] = template.render(**context)
 
-        if resultJson["complete"] and story.apiTrigger:
-            isJson = False
-            parameters = resultJson["extractedParameters"]
+        if resultJson["complete"]: 
+            if story.apiTrigger:
+                isJson = False
+                parameters = resultJson["extractedParameters"]
 
-            urlTemplate = Template(story.apiDetails.url, undefined=SilentUndefined)
-            renderedUrl = urlTemplate.render(**context)
-            if story.apiDetails.isJson:
-                isJson = True
-                requestTemplate = Template(story.apiDetails.jsonData, undefined=SilentUndefined)
-                parameters = requestTemplate.render(**context)
+                urlTemplate = Template(story.apiDetails.url, undefined=SilentUndefined)
+                renderedUrl = urlTemplate.render(**context)
+                if story.apiDetails.isJson:
+                    isJson = True
+                    requestTemplate = Template(story.apiDetails.jsonData, undefined=SilentUndefined)
+                    parameters = requestTemplate.render(**context)
 
-            try:
-                result = callApi(renderedUrl,
-                                 story.apiDetails.requestType,
-                                 parameters,isJson)
-            except Exception as e:
-                print(e)
-                resultJson["speechResponse"] = "Service is not available. "
+                try:
+                    result = callApi(renderedUrl,
+                                     story.apiDetails.requestType,
+                                     parameters,isJson)
+                except Exception as e:
+                    print(e)
+                    resultJson["speechResponse"] = "Service is not available. "
+                else:
+                    print(result)
+                    context["result"] = result
+                    template = Template(story.speechResponse, undefined=SilentUndefined)
+                    resultJson["speechResponse"] = template.render(**context)
             else:
-                print(result)
-                context["result"] = result
+                context["result"] = {}
                 template = Template(story.speechResponse, undefined=SilentUndefined)
                 resultJson["speechResponse"] = template.render(**context)
-        else:
-            context["result"] = {}
-            template = Template(story.speechResponse, undefined=SilentUndefined)
-            resultJson["speechResponse"] = template.render(**context)
         logger.info(requestJson.get("input"), extra=resultJson)
         return buildResponse.buildJson(resultJson)
     else:

--- a/app/endpoint/controllers.py
+++ b/app/endpoint/controllers.py
@@ -134,36 +134,6 @@ def api():
                     resultJson["complete"] = True
 
                     context["parameters"] = extractedParameters
-
-                    try:
-                        if story.apiTrigger:
-                            isJson = False
-                            parameters = extractedParameters
-
-                            urlTemplate = Template(
-                                story.apiDetails.url, undefined=SilentUndefined)
-                            renderedUrl = urlTemplate.render(**context)
-                            if story.apiDetails.isJson:
-                                isJson = True
-                                requestTemplate = Template(
-                                    story.apiDetails.jsonData, undefined=SilentUndefined)
-                                parameters = requestTemplate.render(**context)
-
-                            result = callApi(renderedUrl,
-                                             story.apiDetails.requestType,
-                                             parameters, isJson)
-
-                        else:
-                            result = {}
-
-                        context["result"] = result
-                        resultTemplate = Template(
-                            story.speechResponse, undefined=SilentUndefined)
-                        resultJson["speechResponse"] = resultTemplate.render(
-                            **context)
-                    except Exception as e:
-                        print(e)
-                        resultJson["speechResponse"] = "Service is not available."
             else:
                 resultJson["complete"] = True
                 resultTemplate = Template(
@@ -185,35 +155,6 @@ def api():
                     context = {}
                     context["parameters"] = resultJson["extractedParameters"]
                     context["context"] = requestJson["context"]
-                    try:
-                        if story.apiTrigger:
-                            isJson = False
-                            parameters = resultJson["extractedParameters"]
-
-                            urlTemplate = Template(
-                                story.apiDetails.url, undefined=SilentUndefined)
-                            renderedUrl = urlTemplate.render(**context)
-                            if story.apiDetails.isJson:
-                                isJson = True
-                                requestTemplate = Template(
-                                    story.apiDetails.jsonData, undefined=SilentUndefined)
-                                parameters = requestTemplate.render(**context)
-
-                            result = callApi(renderedUrl,
-                                             story.apiDetails.requestType,
-                                             parameters, isJson)
-                            print(result)
-                        else:
-                            result = {}
-                        context["result"] = result
-
-                        template = Template(
-                            story.speechResponse, undefined=SilentUndefined)
-                        resultJson["speechResponse"] = template.render(
-                            **context)
-                    except Exception as e:
-                        print(e)
-                        resultJson["speechResponse"] = "Service is not available. "
                 else:
                     missingParameter = resultJson["missingParameters"][0]
                     resultJson["complete"] = False
@@ -231,6 +172,34 @@ def api():
                     story.speechResponse,
                     undefined=SilentUndefined)
                 resultJson["speechResponse"] = template.render(**context)
+
+        if resultJson["complete"] and story.apiTrigger:
+            isJson = False
+            parameters = resultJson["extractedParameters"]
+
+            urlTemplate = Template(story.apiDetails.url, undefined=SilentUndefined)
+            renderedUrl = urlTemplate.render(**context)
+            if story.apiDetails.isJson:
+                isJson = True
+                requestTemplate = Template(story.apiDetails.jsonData, undefined=SilentUndefined)
+                parameters = requestTemplate.render(**context)
+
+            try:
+                result = callApi(renderedUrl,
+                                 story.apiDetails.requestType,
+                                 parameters,isJson)
+            except Exception as e:
+                print(e)
+                resultJson["speechResponse"] = "Service is not available. "
+            else:
+                print(result)
+                context["result"] = result
+                template = Template(story.speechResponse, undefined=SilentUndefined)
+                resultJson["speechResponse"] = template.render(**context)
+        else:
+            context["result"] = {}
+            template = Template(story.speechResponse, undefined=SilentUndefined)
+            resultJson["speechResponse"] = template.render(**context)
         logger.info(requestJson.get("input"), extra=resultJson)
         return buildResponse.buildJson(resultJson)
     else:


### PR DESCRIPTION
Move the conditional API calling to the end of request handler. Prior the change, the handler fails to trigger API in some scenario (e.g. when there is no parameter involved and the conversation is complete).