### PR TITLE
Bug fix when integrate with widget

### DIFF
--- a/frontend/src/assets/widget/iky_widget.js
+++ b/frontend/src/assets/widget/iky_widget.js
@@ -72,7 +72,7 @@
             </div>
             `
 
-            document.body.innerHTML += content;
+            $("body").append(content);
 
             $(".iky_container").hide();
             


### PR DESCRIPTION
When i copy and paste this script

`<script type="text/javascript"> !function(win,doc){"use strict";var script_loader=()=>{try {var head=doc.head||doc.getElementsByTagName("head")[0],script=doc.createElement("script");script.setAttribute("type","text/javascript"),script.setAttribute("src",win.iky_base_url+"assets/widget/iky_widget.js"),head.appendChild(script)} catch(e){}};win.chat_context={"username":"John"},win.iky_base_url="http://localhost:8080/",script_loader()}(window,document); </script>
`

the application crashes because of **document.body.innerHTML + = content;**