### PR TITLE
:ok_hand: bugfix SyntaxError: Missing parentheses in call to 'print'

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -13,7 +13,7 @@ def install_nltk_dependencies():
     download("wordnet")
     download('averaged_perceptron_tagger')
     download('punkt')
-    print "Done"
+    print ("Done")
 
 
 @manager.command


### PR DESCRIPTION
After Creation of New Virtual Environment, I received this Error in Python 3.4...

![error received](https://user-images.githubusercontent.com/18069154/45387018-4e1bdd80-b62e-11e8-8f07-bf4740c44d83.png)
