### PR TITLE
StringIO is part of io in  Python 3.x 

### DIFF
--- a/app/intents/controllers.py
+++ b/app/intents/controllers.py
@@ -1,5 +1,5 @@
 import os
-from StringIO import StringIO
+from io import StringIO
 
 from bson.json_util import dumps
 from bson.json_util import loads

--- a/manage.py
+++ b/manage.py
@@ -13,7 +13,7 @@ def install_nltk_dependencies():
     download("wordnet")
     download('averaged_perceptron_tagger')
     download('punkt')
-    print "Done"
+    print ("Done")
 
 
 @manager.command


### PR DESCRIPTION
Python Version 3.5

Answer from the StackOverflow Question
https://stackoverflow.com/questions/30377620/python-3-4-cstringio-vs-stringio

Error Occured:

![image](https://user-images.githubusercontent.com/18069154/45921570-c2c60600-bed1-11e8-84bb-4a8f5f593269.png)
