### PR TITLE
docs: fix simple typo, follwing -> following

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ng build --prod --optimize
 ### DB
 
 #### Restore
-You can import some default intents using follwing steps
+You can import some default intents using following steps
 
 - goto http://localhost:8080/agent/default/settings
 - click 'choose file'


### PR DESCRIPTION
There is a small typo in README.md.

Should read `following` rather than `follwing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md